### PR TITLE
feat(platform): melhoria arquitetural completa — Fases 2-6

### DIFF
--- a/src/features/plataforma/pages/admin/Alunos.tsx
+++ b/src/features/plataforma/pages/admin/Alunos.tsx
@@ -525,7 +525,7 @@ export default function AdminAlunos() {
                   .map((c:any)=> (
                   <div key={c.id} style={{padding:'8px 10px', borderBottom:'1px solid #1e293b', display:'flex', justifyContent:'space-between', gap:8}}>
                     <div>
-                      <div style={{fontSize:12, color:'#9fb2c5'}}>{new Date(c.created_at).toLocaleString('pt-BR')} • Vídeo: {c.video_id} • Status: {(c.status||'pendente')}</div>
+                      <div style={{fontSize:12, color:'#9fb2c5'}}>{new Date(c.created_at).toLocaleString('pt-BR')} • Aula: {c.lesson_id} • Status: {(c.status||'pendente')}</div>
                       <div>{c.text}</div>
                     </div>
                     <div style={{display:'flex', gap:6}}>

--- a/src/features/plataforma/pages/modulosMestre.tsx
+++ b/src/features/plataforma/pages/modulosMestre.tsx
@@ -76,10 +76,10 @@ const ModulosMestre = () => {
         const rows = await fetchUserProgress(uid, 100);
         let best: string | null = null; let bestAt = 0;
         rows.forEach(r => {
-          if (completedIds.has(r.video_id)) return;
-          if (idSet.has(r.video_id) || urlSet.has(r.video_id)) {
+          if (completedIds.has(r.lesson_id)) return;
+          if (idSet.has(r.lesson_id) || urlSet.has(r.lesson_id)) {
             const at = new Date(r.last_at).getTime();
-            if (at > bestAt) { bestAt = at; best = r.video_id; }
+            if (at > bestAt) { bestAt = at; best = r.lesson_id; }
           }
         });
         if (!navigated) {

--- a/src/features/plataforma/pages/plataforma.tsx
+++ b/src/features/plataforma/pages/plataforma.tsx
@@ -146,7 +146,7 @@ const PaginaInicial = () => {
             // enquanto localStorage já tem a posição real assistida.
             const localWatched = (() => {
               try {
-                const raw = localStorage.getItem(`fiveone_progress::${r.video_id}`);
+                const raw = localStorage.getItem(`fiveone_progress::${r.lesson_id}`);
                 if (!raw) return 0;
                 const parsed = JSON.parse(raw);
                 return Number(parsed.watchedSeconds || parsed.watched || 0);
@@ -154,7 +154,7 @@ const PaginaInicial = () => {
             })();
             const watchedSeconds = Math.max(r.watched_seconds, localWatched);
             return {
-              id: r.video_id,
+              id: r.lesson_id,
               url: '',
               index: undefined,
               title: r.title,
@@ -162,14 +162,14 @@ const PaginaInicial = () => {
               watchedSeconds,
               durationSeconds: r.duration_seconds || undefined,
               lastAt: new Date(r.last_at).getTime(),
-              subjectName: lessonByVideoId.get(r.video_id)?.subjectName,
+              subjectName: lessonByVideoId.get(r.lesson_id)?.subjectName,
               bannerContinue:
-                lessonByVideoId.get(r.video_id)?.bannerContinue?.url ||
-                lessonByVideoId.get(r.video_id)?.bannerContinue?.dataUrl ||
+                lessonByVideoId.get(r.lesson_id)?.bannerContinue?.url ||
+                lessonByVideoId.get(r.lesson_id)?.bannerContinue?.dataUrl ||
                 null,
               bannerMobile:
-                lessonByVideoId.get(r.video_id)?.bannerMobile?.url ||
-                lessonByVideoId.get(r.video_id)?.bannerMobile?.dataUrl ||
+                lessonByVideoId.get(r.lesson_id)?.bannerMobile?.url ||
+                lessonByVideoId.get(r.lesson_id)?.bannerMobile?.dataUrl ||
                 null,
             };
           });

--- a/src/features/plataforma/pages/streamerMestre.tsx
+++ b/src/features/plataforma/pages/streamerMestre.tsx
@@ -967,7 +967,7 @@ const StreamerMestre = () => {
           sessionStorage.setItem(syncKey, String(now));
           upsertProgress({
             user_id: userId,
-            video_id: lesson.videoId,
+            lesson_id: lesson.videoId,
             last_at: new Date(now).toISOString(),
             watched_seconds: watchedSeconds,
             duration_seconds: durationSeconds || null,

--- a/src/features/plataforma/services/comments.ts
+++ b/src/features/plataforma/services/comments.ts
@@ -3,7 +3,7 @@ import { supabase } from "../../../shared/lib/supabaseClient";
 export type VideoComment = {
   id: string;
   user_id: string;
-  video_id: string;
+  lesson_id: string;
   text: string;
   created_at: string;
   likes: number;
@@ -25,18 +25,18 @@ export async function fetchComments(videoId: string): Promise<VideoComment[]> {
     supabase
       .from('platform_lesson_comment')
       .select(fields)
-      .eq('video_id', videoId)
+      .eq('lesson_id', videoId)
       .order('created_at', { ascending: true });
 
   if (supportsCommentProfileJoin === false) {
-    const fallback = await run('id,user_id,video_id,text,created_at,likes,parent_id');
+    const fallback = await run('id,user_id,lesson_id,text,created_at,likes,parent_id');
     if (fallback.error) throw fallback.error;
     return (fallback.data || []) as any;
   }
 
   // Tenta trazer o perfil junto (requer FK/relationship configurado no banco).
   const withProfile = await run(
-    'id,user_id,video_id,text,created_at,likes,parent_id,profile:platform_user_profile(display_name,first_name,last_name,avatar_url)',
+    'id,user_id,lesson_id,text,created_at,likes,parent_id,profile:platform_user_profile(display_name,first_name,last_name,avatar_url)',
   );
 
   if (!withProfile.error) {
@@ -58,13 +58,13 @@ export async function fetchComments(videoId: string): Promise<VideoComment[]> {
 
   supportsCommentProfileJoin = false;
   console.warn('fetchComments: fallback sem profile por incompatibilidade no banco:', withProfile.error);
-  const fallback = await run('id,user_id,video_id,text,created_at,likes,parent_id');
+  const fallback = await run('id,user_id,lesson_id,text,created_at,likes,parent_id');
   if (fallback.error) throw fallback.error;
   return (fallback.data || []) as any;
 }
 
 export async function addComment(userId: string, videoId: string, text: string, parentId?: string | null): Promise<void> {
-  const payload: Record<string, any> = { user_id: userId, video_id: videoId, text, likes: 0 };
+  const payload: Record<string, any> = { user_id: userId, lesson_id: videoId, text, likes: 0 };
   if (parentId) payload.parent_id = parentId;
   const { error } = await supabase.from('platform_lesson_comment').insert(payload);
   if (error) throw error;

--- a/src/features/plataforma/services/completions.ts
+++ b/src/features/plataforma/services/completions.ts
@@ -1,21 +1,21 @@
 import { supabase } from "../../../shared/lib/supabaseClient";
 
 export async function upsertCompletion(userId: string, videoId: string): Promise<void> {
-  await supabase.from('platform_lesson_completion').upsert({ user_id: userId, video_id: videoId, completed_at: new Date().toISOString() });
+  await supabase.from('platform_lesson_completion').upsert({ user_id: userId, lesson_id: videoId, completed_at: new Date().toISOString() });
 }
 
 export async function fetchCompletion(userId: string, videoId: string): Promise<boolean> {
-  const { data } = await supabase.from('platform_lesson_completion').select('user_id').eq('user_id', userId).eq('video_id', videoId).maybeSingle();
+  const { data } = await supabase.from('platform_lesson_completion').select('user_id').eq('user_id', userId).eq('lesson_id', videoId).maybeSingle();
   return !!data;
 }
 
 export async function fetchCompletionsForUser(userId: string): Promise<string[]> {
   const { data, error } = await supabase
     .from('platform_lesson_completion')
-    .select('video_id')
+    .select('lesson_id')
     .eq('user_id', userId);
   if (error) throw error;
-  return (data || []).map((r: any) => r.video_id);
+  return (data || []).map((r: any) => r.lesson_id);
 }
 
 export async function deleteCompletion(userId: string, videoId: string): Promise<void> {
@@ -23,7 +23,7 @@ export async function deleteCompletion(userId: string, videoId: string): Promise
     .from('platform_lesson_completion')
     .delete()
     .eq('user_id', userId)
-    .eq('video_id', videoId);
+    .eq('lesson_id', videoId);
   if (error) throw error;
 }
 

--- a/src/features/plataforma/services/progress.ts
+++ b/src/features/plataforma/services/progress.ts
@@ -2,7 +2,7 @@ import { supabase } from "../../../shared/lib/supabaseClient";
 
 export type ProgressRow = {
   user_id: string;
-  video_id: string;
+  lesson_id: string;
   last_at: string; // ISO string
   watched_seconds: number;
   duration_seconds: number | null;
@@ -13,7 +13,7 @@ export type ProgressRow = {
 export async function fetchUserProgress(userId: string, limit = 20): Promise<ProgressRow[]> {
   const { data, error } = await supabase
     .from("platform_user_progress")
-    .select("user_id, video_id, last_at, watched_seconds, duration_seconds, title, thumbnail")
+    .select("user_id, lesson_id, last_at, watched_seconds, duration_seconds, title, thumbnail")
     .eq("user_id", userId)
     .order("last_at", { ascending: false })
     .limit(limit);
@@ -24,7 +24,7 @@ export async function fetchUserProgress(userId: string, limit = 20): Promise<Pro
 export async function upsertProgress(row: ProgressRow): Promise<void> {
   const { error } = await supabase
     .from("platform_user_progress")
-    .upsert(row, { onConflict: "user_id,video_id" });
+    .upsert(row, { onConflict: "user_id,lesson_id" });
   if (error) throw error;
 }
 
@@ -44,7 +44,7 @@ export async function deleteProgressExceptForUser(userId: string, keepVideoIds: 
 
   if (keepVideoIds.length) {
     const formatted = `(${keepVideoIds.map((id) => `"${id.replace(/"/g, '\\"')}"`).join(',')})`;
-    query = query.not('video_id', 'in', formatted);
+    query = query.not('lesson_id', 'in', formatted);
   }
 
   const { error } = await query;
@@ -56,14 +56,14 @@ export async function deleteProgressForUserVideo(userId: string, videoId: string
     .from('platform_user_progress')
     .delete()
     .eq('user_id', userId)
-    .eq('video_id', videoId);
+    .eq('lesson_id', videoId);
   if (error) throw error;
 }
 
 export function toLocalRow(row: any): ProgressRow {
   return {
     user_id: row.user_id,
-    video_id: row.video_id,
+    lesson_id: row.lesson_id,
     last_at: row.last_at,
     watched_seconds: Number(row.watched_seconds || 0),
     duration_seconds: row.duration_seconds ? Number(row.duration_seconds) : null,

--- a/src/features/plataforma/services/reactions.ts
+++ b/src/features/plataforma/services/reactions.ts
@@ -8,18 +8,45 @@ export type ReactionState = {
 };
 
 export async function fetchReactionState(userId: string | null, videoId: string): Promise<ReactionState> {
+  // RPC get_reaction_state: agrupa 3 queries em 1 round-trip
+  try {
+    const { data, error } = await supabase
+      .rpc('get_reaction_state', {
+        p_user_id:   userId ?? '',
+        p_lesson_id: videoId,
+      })
+      .maybeSingle();
+
+    if (!error && data) {
+      const row = data as { like_count: number; dislike_count: number; user_reaction: string | null };
+      const selected = (row.user_reaction === 'like' || row.user_reaction === 'dislike')
+        ? row.user_reaction as ReactionType
+        : null;
+      return {
+        selected,
+        counts: {
+          like:    Number(row.like_count    ?? 0),
+          dislike: Number(row.dislike_count ?? 0),
+        },
+      };
+    }
+  } catch {
+    // fallback abaixo
+  }
+
+  // Fallback: 3 queries separadas caso a RPC não esteja disponível
   const counts = { like: 0, dislike: 0 };
   try {
     const [likeRes, dislikeRes] = await Promise.all([
       supabase
         .from("platform_lesson_reaction")
         .select("reaction", { count: "exact", head: true })
-        .eq("video_id", videoId)
+        .eq("lesson_id", videoId)
         .eq("reaction", "like"),
       supabase
         .from("platform_lesson_reaction")
         .select("reaction", { count: "exact", head: true })
-        .eq("video_id", videoId)
+        .eq("lesson_id", videoId)
         .eq("reaction", "dislike"),
     ]);
     if (!likeRes.error && typeof likeRes.count === "number") counts.like = likeRes.count;
@@ -33,7 +60,7 @@ export async function fetchReactionState(userId: string | null, videoId: string)
     const { data: me, error: errMe } = await supabase
       .from('platform_lesson_reaction')
       .select('reaction')
-      .eq('video_id', videoId)
+      .eq('lesson_id', videoId)
       .eq('user_id', userId)
       .maybeSingle();
     if (!errMe && me) {
@@ -52,10 +79,10 @@ export async function setReaction(userId: string, videoId: string, reaction: Rea
       .from('platform_lesson_reaction')
       .delete()
       .eq('user_id', userId)
-      .eq('video_id', videoId);
+      .eq('lesson_id', videoId);
     return;
   }
   await supabase
     .from("platform_lesson_reaction")
-    .upsert({ user_id: userId, video_id: videoId, reaction }, { onConflict: "user_id,video_id" });
+    .upsert({ user_id: userId, lesson_id: videoId, reaction }, { onConflict: "user_id,lesson_id" });
 }

--- a/src/features/plataforma/services/userAccount.ts
+++ b/src/features/plataforma/services/userAccount.ts
@@ -233,12 +233,12 @@ export async function getUserByEmail(email: string): Promise<PlatformUserListIte
 }
 
 // Comments API (platform_lesson_comment)
-export type UserComment = { id: string; video_id: string; text: string; likes: number | null; created_at: string; status?: 'pendente' | 'aprovado' };
+export type UserComment = { id: string; lesson_id: string; text: string; likes: number | null; created_at: string; status?: 'pendente' | 'aprovado' };
 
 export async function getUserComments(email: string): Promise<UserComment[]> {
   const { data, error } = await supabase
     .from('platform_lesson_comment')
-    .select('id,video_id,text,likes,created_at,status')
+    .select('id,lesson_id,text,likes,created_at,status')
     .eq('user_id', email.toLowerCase())
     .order('created_at', { ascending: false });
   if (error) throw error;

--- a/supabase/migrations/20260307030000_platform_fks_and_auto_profile.sql
+++ b/supabase/migrations/20260307030000_platform_fks_and_auto_profile.sql
@@ -1,0 +1,84 @@
+-- Migration: FKs com CASCADE + trigger auto-criação de platform_user_profile
+--
+-- 1. Remove dados órfãos (lesson_id sem correspondente em platform_lesson)
+--    que ficaram porque não havia FK antes. São dados de testes/lições deletadas.
+--
+-- 2. Adiciona FKs de lesson_id → platform_lesson.id com ON DELETE CASCADE
+--    em todas as tabelas de tracking. Ao deletar uma lição, todos os dados
+--    associados (progresso, conclusão, reações, comentários) são removidos.
+--
+-- 3. Cria trigger para auto-criar platform_user_profile quando um novo
+--    platform_user é inserido (elimina passo manual/esquecido no frontend).
+--
+-- 4. Backfill: cria perfis para os usuários que já existem sem perfil.
+
+-- ── 1. Limpar dados órfãos ────────────────────────────────────────────────────
+
+DELETE FROM public.platform_user_progress
+WHERE lesson_id NOT IN (SELECT id FROM public.platform_lesson);
+
+DELETE FROM public.platform_lesson_completion
+WHERE lesson_id NOT IN (SELECT id FROM public.platform_lesson);
+
+DELETE FROM public.platform_lesson_reaction
+WHERE lesson_id NOT IN (SELECT id FROM public.platform_lesson);
+
+-- Comentários: remover filhos antes dos pais para não violar a FK self-ref
+DELETE FROM public.platform_lesson_comment
+WHERE parent_id IS NOT NULL
+  AND lesson_id NOT IN (SELECT id FROM public.platform_lesson);
+
+DELETE FROM public.platform_lesson_comment
+WHERE lesson_id NOT IN (SELECT id FROM public.platform_lesson);
+
+-- ── 2. FKs lesson_id → platform_lesson.id ────────────────────────────────────
+
+ALTER TABLE public.platform_user_progress
+  ADD CONSTRAINT fk_progress_lesson
+    FOREIGN KEY (lesson_id) REFERENCES public.platform_lesson(id)
+    ON DELETE CASCADE;
+
+ALTER TABLE public.platform_lesson_completion
+  ADD CONSTRAINT fk_completion_lesson
+    FOREIGN KEY (lesson_id) REFERENCES public.platform_lesson(id)
+    ON DELETE CASCADE;
+
+ALTER TABLE public.platform_lesson_reaction
+  ADD CONSTRAINT fk_reaction_lesson
+    FOREIGN KEY (lesson_id) REFERENCES public.platform_lesson(id)
+    ON DELETE CASCADE;
+
+ALTER TABLE public.platform_lesson_comment
+  ADD CONSTRAINT fk_comment_lesson
+    FOREIGN KEY (lesson_id) REFERENCES public.platform_lesson(id)
+    ON DELETE CASCADE;
+
+-- ── 3. Trigger: auto-criar platform_user_profile ao inserir platform_user ────
+
+CREATE OR REPLACE FUNCTION public.auto_create_user_profile()
+  RETURNS trigger
+  LANGUAGE plpgsql
+  SET search_path = public
+AS $$
+BEGIN
+  INSERT INTO public.platform_user_profile (user_email)
+  VALUES (NEW.email)
+  ON CONFLICT (user_email) DO NOTHING;
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trg_auto_create_user_profile
+  AFTER INSERT ON public.platform_user
+  FOR EACH ROW
+  EXECUTE FUNCTION public.auto_create_user_profile();
+
+-- ── 4. Backfill: perfis para usuários sem perfil ──────────────────────────────
+
+INSERT INTO public.platform_user_profile (user_email)
+SELECT pu.email
+FROM public.platform_user pu
+WHERE NOT EXISTS (
+  SELECT 1 FROM public.platform_user_profile pp
+  WHERE pp.user_email = pu.email
+);

--- a/supabase/migrations/20260307040000_platform_denormalized_counters.sql
+++ b/supabase/migrations/20260307040000_platform_denormalized_counters.sql
@@ -1,0 +1,92 @@
+-- Migration: Colunas desnormalizadas + triggers de contadores
+--
+-- Adiciona colunas de analytics em platform_lesson e platform_user para
+-- permitir dashboards rápidos sem N+1 queries ao banco.
+--
+-- Os triggers mantêm os contadores sincronizados automaticamente.
+-- O backfill inicial calcula os valores corretos a partir dos dados existentes.
+
+-- ── 1. Colunas de analytics em platform_lesson ────────────────────────────────
+
+ALTER TABLE public.platform_lesson
+  ADD COLUMN IF NOT EXISTS views_count      integer      NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS completion_count integer      NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS last_viewed_at   timestamptz;
+
+-- ── 2. Colunas de analytics em platform_user ──────────────────────────────────
+
+ALTER TABLE public.platform_user
+  ADD COLUMN IF NOT EXISTS total_lessons_completed integer NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS last_login_at           timestamptz;
+
+-- ── 3. Backfill: calcular valores iniciais a partir de dados existentes ────────
+
+UPDATE public.platform_lesson l
+SET
+  views_count = (
+    SELECT COUNT(*) FROM public.platform_user_progress up
+    WHERE up.lesson_id = l.id
+  ),
+  completion_count = (
+    SELECT COUNT(*) FROM public.platform_lesson_completion lc
+    WHERE lc.lesson_id = l.id
+  ),
+  last_viewed_at = (
+    SELECT MAX(up.last_at) FROM public.platform_user_progress up
+    WHERE up.lesson_id = l.id
+  );
+
+UPDATE public.platform_user u
+SET total_lessons_completed = (
+  SELECT COUNT(*) FROM public.platform_lesson_completion lc
+  WHERE lc.user_id = u.email
+);
+
+-- ── 4. Trigger: incrementar views_count + atualizar last_viewed_at ────────────
+
+CREATE OR REPLACE FUNCTION public.trg_fn_update_lesson_views()
+  RETURNS trigger
+  LANGUAGE plpgsql
+  SET search_path = public
+AS $$
+BEGIN
+  UPDATE public.platform_lesson
+  SET
+    views_count    = views_count + 1,
+    last_viewed_at = NEW.last_at
+  WHERE id = NEW.lesson_id;
+  RETURN NEW;
+END;
+$$;
+
+-- Dispara apenas em INSERT (novo progresso = nova visualização)
+CREATE TRIGGER trg_lesson_views_count
+  AFTER INSERT ON public.platform_user_progress
+  FOR EACH ROW
+  EXECUTE FUNCTION public.trg_fn_update_lesson_views();
+
+-- ── 5. Trigger: incrementar completion_count + total_lessons_completed ─────────
+
+CREATE OR REPLACE FUNCTION public.trg_fn_update_lesson_completions()
+  RETURNS trigger
+  LANGUAGE plpgsql
+  SET search_path = public
+AS $$
+BEGIN
+  UPDATE public.platform_lesson
+  SET completion_count = completion_count + 1
+  WHERE id = NEW.lesson_id;
+
+  UPDATE public.platform_user
+  SET total_lessons_completed = total_lessons_completed + 1
+  WHERE email = NEW.user_id;
+
+  RETURN NEW;
+END;
+$$;
+
+-- Dispara apenas em INSERT (conclusão é evento único por ON CONFLICT DO NOTHING)
+CREATE TRIGGER trg_lesson_completion_count
+  AFTER INSERT ON public.platform_lesson_completion
+  FOR EACH ROW
+  EXECUTE FUNCTION public.trg_fn_update_lesson_completions();

--- a/supabase/migrations/20260307050000_platform_rpcs.sql
+++ b/supabase/migrations/20260307050000_platform_rpcs.sql
@@ -1,0 +1,96 @@
+-- Migration: RPCs da plataforma de ensino
+--
+-- Substitui múltiplas queries no frontend por chamadas únicas e atômicas:
+--
+--   get_reaction_state   → agrupa 3 queries de reactions em 1 (N+1 → 1)
+--   mark_lesson_complete → UPSERT atômico de completion
+--   get_lesson_with_progress → carrega player em 1 round-trip ao invés de 4+
+
+-- ── RPC 1: get_reaction_state ─────────────────────────────────────────────────
+-- Retorna contagens de likes/dislikes + reação do usuário autenticado.
+-- Substitui: 2 × COUNT queries + 1 × SELECT em reactions.ts
+
+CREATE OR REPLACE FUNCTION public.get_reaction_state(
+  p_user_id   text,
+  p_lesson_id text
+)
+RETURNS TABLE(
+  like_count    bigint,
+  dislike_count bigint,
+  user_reaction text
+)
+LANGUAGE sql
+SECURITY DEFINER
+STABLE
+SET search_path = public
+AS $$
+  SELECT
+    COUNT(*) FILTER (WHERE reaction = 'like')                          AS like_count,
+    COUNT(*) FILTER (WHERE reaction = 'dislike')                       AS dislike_count,
+    MAX(reaction) FILTER (WHERE user_id = lower(p_user_id))            AS user_reaction
+  FROM public.platform_lesson_reaction
+  WHERE lesson_id = p_lesson_id;
+$$;
+
+-- ── RPC 2: mark_lesson_complete ───────────────────────────────────────────────
+-- UPSERT atômico que registra conclusão de lição.
+-- Usa ON CONFLICT DO NOTHING para ser idempotente.
+
+CREATE OR REPLACE FUNCTION public.mark_lesson_complete(
+  p_user_email text,
+  p_lesson_id  text
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  INSERT INTO public.platform_lesson_completion (user_id, lesson_id, completed_at)
+  VALUES (lower(p_user_email), p_lesson_id, now())
+  ON CONFLICT (user_id, lesson_id) DO NOTHING;
+END;
+$$;
+
+-- ── RPC 3: get_lesson_with_progress ──────────────────────────────────────────
+-- Carrega todos os dados do player em 1 única query (substitui 4+ round-trips):
+--   - is_completed (se o usuário já concluiu)
+--   - watched_seconds / duration_seconds / last_watched_at
+--   - like_count / dislike_count / user_reaction
+
+CREATE OR REPLACE FUNCTION public.get_lesson_with_progress(
+  p_user_email text,
+  p_lesson_id  text
+)
+RETURNS TABLE(
+  is_completed     boolean,
+  watched_seconds  integer,
+  duration_seconds integer,
+  last_watched_at  timestamptz,
+  user_reaction    text,
+  like_count       bigint,
+  dislike_count    bigint
+)
+LANGUAGE sql
+SECURITY DEFINER
+STABLE
+SET search_path = public
+AS $$
+  SELECT
+    (lc.user_id IS NOT NULL)::boolean                                          AS is_completed,
+    COALESCE(up.watched_seconds,  0)::integer                                  AS watched_seconds,
+    COALESCE(up.duration_seconds, 0)::integer                                  AS duration_seconds,
+    up.last_at                                                                 AS last_watched_at,
+    MAX(lr.reaction) FILTER (WHERE lr.user_id = lower(p_user_email))           AS user_reaction,
+    COUNT(lr.lesson_id) FILTER (WHERE lr.reaction = 'like')                    AS like_count,
+    COUNT(lr.lesson_id) FILTER (WHERE lr.reaction = 'dislike')                 AS dislike_count
+  FROM public.platform_lesson l
+  LEFT JOIN public.platform_user_progress    up
+         ON l.id = up.lesson_id AND up.user_id = lower(p_user_email)
+  LEFT JOIN public.platform_lesson_completion lc
+         ON l.id = lc.lesson_id AND lc.user_id = lower(p_user_email)
+  LEFT JOIN public.platform_lesson_reaction  lr
+         ON l.id = lr.lesson_id
+  WHERE l.id = p_lesson_id
+  GROUP BY lc.user_id, up.watched_seconds, up.duration_seconds, up.last_at;
+$$;

--- a/supabase/migrations/20260307060000_platform_new_features.sql
+++ b/supabase/migrations/20260307060000_platform_new_features.sql
@@ -1,0 +1,114 @@
+-- Migration: Novos recursos da plataforma de ensino
+--
+-- 6a. Tabela platform_favorite_lesson — favoritar aulas
+-- 6b. Tabela platform_certificate     — certificados de conclusão de ministério
+-- 6c. Full-text search                — coluna search_vector + índice GIN + RPC
+
+-- ── 6a. Favoritos ─────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS public.platform_favorite_lesson (
+  user_id    text        NOT NULL REFERENCES public.platform_user(email)  ON DELETE CASCADE,
+  lesson_id  text        NOT NULL REFERENCES public.platform_lesson(id)   ON DELETE CASCADE,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (user_id, lesson_id)
+);
+
+ALTER TABLE public.platform_favorite_lesson ENABLE ROW LEVEL SECURITY;
+
+-- Usuário só acessa seus próprios favoritos
+CREATE POLICY "favorites_own" ON public.platform_favorite_lesson
+  FOR ALL
+  TO authenticated
+  USING  (user_id = (SELECT auth.email()))
+  WITH CHECK (user_id = (SELECT auth.email()));
+
+CREATE INDEX idx_favorite_lesson_user
+  ON public.platform_favorite_lesson (user_id, created_at DESC);
+
+-- ── 6b. Certificados ──────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS public.platform_certificate (
+  id           uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id      text        NOT NULL REFERENCES public.platform_user(email)    ON DELETE CASCADE,
+  ministry_id  text        NOT NULL REFERENCES public.platform_ministry(id)   ON DELETE RESTRICT,
+  issued_at    timestamptz NOT NULL DEFAULT now(),
+  file_url     text,
+  verify_code  text        UNIQUE NOT NULL DEFAULT encode(gen_random_bytes(12), 'hex')
+);
+
+ALTER TABLE public.platform_certificate ENABLE ROW LEVEL SECURITY;
+
+-- Aluno vê apenas os próprios; admin vê todos
+CREATE POLICY "cert_select" ON public.platform_certificate
+  FOR SELECT
+  TO authenticated
+  USING (
+    user_id = (SELECT auth.email())
+    OR (SELECT public.is_platform_admin())
+  );
+
+-- Apenas admin emite certificados
+CREATE POLICY "cert_insert_admin" ON public.platform_certificate
+  FOR INSERT
+  TO authenticated
+  WITH CHECK ((SELECT public.is_platform_admin()));
+
+-- Apenas admin pode deletar/atualizar certificados
+CREATE POLICY "cert_modify_admin" ON public.platform_certificate
+  FOR ALL
+  TO authenticated
+  USING ((SELECT public.is_platform_admin()));
+
+CREATE INDEX idx_certificate_user_ministry
+  ON public.platform_certificate (user_id, ministry_id);
+
+-- ── 6c. Full-text search ──────────────────────────────────────────────────────
+
+-- Coluna gerada automaticamente — atualizada sempre que title/subtitle/etc mudam
+ALTER TABLE public.platform_lesson
+  ADD COLUMN IF NOT EXISTS search_vector tsvector
+    GENERATED ALWAYS AS (
+      to_tsvector(
+        'portuguese',
+        coalesce(title,        '') || ' ' ||
+        coalesce(subtitle,     '') || ' ' ||
+        coalesce(description,  '') || ' ' ||
+        coalesce(subject_name, '') || ' ' ||
+        coalesce(instructor,   '')
+      )
+    ) STORED;
+
+-- Índice GIN para buscas full-text eficientes
+CREATE INDEX IF NOT EXISTS idx_lesson_fts
+  ON public.platform_lesson USING gin(search_vector);
+
+-- RPC: search_lessons — busca full-text com filtro opcional por ministério
+CREATE OR REPLACE FUNCTION public.search_lessons(
+  p_query       text,
+  p_ministry_id text DEFAULT NULL
+)
+RETURNS SETOF public.platform_lesson
+LANGUAGE sql
+SECURITY DEFINER
+STABLE
+SET search_path = public
+AS $$
+  SELECT l.*
+  FROM public.platform_lesson l
+  JOIN public.platform_module m ON l.module_id = m.id
+  WHERE l.status     = 'published'
+    AND l.is_active  = true
+    AND (p_ministry_id IS NULL OR m.ministry_id = p_ministry_id)
+    AND (
+      p_query IS NULL
+      OR p_query = ''
+      OR l.search_vector @@ websearch_to_tsquery('portuguese', p_query)
+    )
+  ORDER BY
+    CASE
+      WHEN p_query IS NULL OR p_query = '' THEN 0
+      ELSE -ts_rank(l.search_vector, websearch_to_tsquery('portuguese', p_query))
+    END,
+    l.views_count DESC
+  LIMIT 50;
+$$;


### PR DESCRIPTION
- Renomeia video_id → lesson_id em todos os serviços e páginas da plataforma (reactions, comments, progress, completions, userAccount, plataforma, modulosMestre, streamerMestre, admin/Alunos)
- Adiciona migrations 03-06: 03: FKs ON DELETE CASCADE + trigger auto-criação de perfil de usuário 04: colunas desnormalizadas (views_count, completion_count) + triggers 05: RPCs get_reaction_state, mark_lesson_complete, get_lesson_with_progress 06: tabelas platform_favorite_lesson, platform_certificate + FTS em português
- reactions.ts: usa RPC get_reaction_state com fallback para queries individuais
- Compatível com nova estrutura de pastas src/features/plataforma/